### PR TITLE
gymnasium 0.26.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,6 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.18.0
-    - {{ pin_compatible('numpy') }}
 
 outputs:
   - name: gymnasium

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Farama-Foundation/Gymnasium/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: bac0e8e1a9c672568d8673ec34588eb80807a2067964c3dc90a97d7fb2f51460
+  sha256: bdb641c4cde0916aca339f736764b89077cdc147ed274a2ea6023c043c8d48e7
 
 build:
   number: 0
@@ -16,7 +16,7 @@ requirements:
   host:
     - python
     - pip
-    - cloudpickle >=1.2.0
+    - cloudpickle
     - numpy
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - wheel
   run:
     - python
+    - {{ pin_compatible('numpy') }}
 
 outputs:
   - name: gymnasium

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,11 @@ requirements:
     - python
     - pip
     - cloudpickle
-    - numpy
+    - numpy 1.19   # [py<310]
+    - numpy 1.21   # [py==310]
+    - numpy 1.23   # [py>=311]
     - setuptools
     - wheel
-  run:
-    - python
 
 outputs:
   - name: gymnasium

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - wheel
   run:
     - python
+    - numpy >=1.18.0
     - {{ pin_compatible('numpy') }}
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,7 @@ requirements:
     - python
     - pip
     - cloudpickle
-    - numpy   1.19   # [py<310]
-    - numpy   1.21   # [py==310]
-    - numpy   1.23   # [py>=311]
+    - numpy
     - setuptools
     - wheel
   run:
@@ -35,9 +33,7 @@ outputs:
       host:
         - python
         - cloudpickle
-        - numpy   1.19   # [py<310]
-        - numpy   1.21   # [py==310]
-        - numpy   1.23   # [py>=311]
+        - numpy
         - pip
         - setuptools
         - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.27.1" %}
+{% set version = "0.26.3" %}
 
 package:
   name: gymnasium-split
@@ -13,13 +13,11 @@ build:
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
   host:
     - python
     - pip
+    - cloudpickle >=1.2.0
+    - numpy
     - setuptools
     - wheel
   run:
@@ -30,28 +28,26 @@ outputs:
     build:
       script: {{ PYTHON }} -m pip install . -vv --no-deps
     requirements:
-      build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - numpy                                  # [build_platform != target_platform]
       host:
         - python
-        - pip
-        - cloudpickle >=1.2.0
+        - cloudpickle
         - numpy
+        - pip
+        - setuptools
+        - wheel
       run:
         - python
         - cloudpickle >=1.2.0
         - gymnasium-notices
-        - numpy
-        - jax-jumpy
-        - typing_extensions
         - importlib_metadata >=4.8.1  # [py<=39]
+        - numpy >=1.18.0
     test:
       imports:
         - gymnasium
 
   - name: gymnasium-all
+    build:
+      skip: True
     requirements:
       host:
         - python
@@ -95,6 +91,9 @@ outputs:
         - gymnasium.envs.atari
 
   - name: gymnasium-box2d
+    build:
+      # we currently don't have box2d-py
+      skip: true
     requirements:
       host:
         - python
@@ -109,6 +108,9 @@ outputs:
         - gymnasium.envs.box2d
 
   - name: gymnasium-classic_control
+    build:
+      # we currently don't have pygame
+      skip: true
     requirements:
       host:
         - python
@@ -121,6 +123,9 @@ outputs:
         - gymnasium.envs.classic_control
 
   - name: gymnasium-mujoco
+    build:
+      # we currently don't have mujoco-python
+      skip: true
     requirements:
       host:
         - python
@@ -151,6 +156,9 @@ outputs:
         - gymnasium.envs.mujoco
 
   - name: gymnasium-toy_text
+    build:
+      # we currently don't have pygame
+      skip: true
     requirements:
       host:
         - python
@@ -163,6 +171,9 @@ outputs:
         - gymnasium.envs.toy_text
 
   - name: gymnasium-other
+    build:
+      # we currently don't have moviepy
+      skip: true
     requirements:
       host:
         - python
@@ -183,6 +194,12 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: A standard API for reinforcement learning and a diverse set of reference environments (formerly Gym)
+  description: |
+    Gymnasium is an open source Python library for developing and comparing reinforcement learning algorithms 
+    by providing a standard API to communicate between learning algorithms and environments, 
+    as well as a standard set of environments compliant with that API. 
+    This is a fork of OpenAI's Gym library by the maintainers 
+    (OpenAI handed over maintenance a few years ago to an outside team), and is where future maintenance will occur going forward
   dev_url: https://github.com/Farama-Foundation/Gymnasium
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ outputs:
         - cloudpickle >=1.2.0
         - gymnasium-notices
         - importlib_metadata >=4.8.1  # [py<=39]
+        - numpy >=1.18.0
         - {{ pin_compatible('numpy') }}
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,9 @@ outputs:
       host:
         - python
         - cloudpickle
-        - numpy
+        - numpy 1.19   # [py<310]
+        - numpy 1.21   # [py==310]
+        - numpy 1.23   # [py>=311]
         - pip
         - setuptools
         - wheel
@@ -40,7 +42,6 @@ outputs:
         - cloudpickle >=1.2.0
         - gymnasium-notices
         - importlib_metadata >=4.8.1  # [py<=39]
-        - numpy >=1.18.0
         - {{ pin_compatible('numpy') }}
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,9 @@ requirements:
     - python
     - pip
     - cloudpickle
-    - numpy
+    - numpy   1.19   # [py<310]
+    - numpy   1.21   # [py==310]
+    - numpy   1.23   # [py>=311]
     - setuptools
     - wheel
   run:
@@ -31,7 +33,9 @@ outputs:
       host:
         - python
         - cloudpickle
-        - numpy
+        - numpy   1.19   # [py<310]
+        - numpy   1.21   # [py==310]
+        - numpy   1.23   # [py>=311]
         - pip
         - setuptools
         - wheel
@@ -40,7 +44,7 @@ outputs:
         - cloudpickle >=1.2.0
         - gymnasium-notices
         - importlib_metadata >=4.8.1  # [py<=39]
-        - numpy >=1.18.0
+        - {{ pin_compatible('numpy') }}
     test:
       imports:
         - gymnasium
@@ -201,6 +205,7 @@ about:
     This is a fork of OpenAI's Gym library by the maintainers 
     (OpenAI handed over maintenance a few years ago to an outside team), and is where future maintenance will occur going forward
   dev_url: https://github.com/Farama-Foundation/Gymnasium
+  doc_url: https://gymnasium.farama.org/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/Farama-Foundation/Gymnasium/blob/v0.26.3/LICENSE
Changelog: https://github.com/Farama-Foundation/Gymnasium/releases
Requirements: https://github.com/Farama-Foundation/Gymnasium/blob/v0.26.3/requirements.txt

Actions:
1. Skip `gymnasium-all `and sub-packages
2. Remove `requirements/build` section
4. Add `numpy` to the general `host` env, remove pinnings
5. Add `setuptools` & `wheel` to `gymnasium` subpackage's `host` env
6. Fix pinning in `run`: `numpy >=1.18.0`
7. Remove `jax-jumpy` & `typing_extensions`, they are needed for **v0.27.1** only.
8. Add `description`
9. Add `doc_url`


Notes:
- `ray-rllib` subpackage of `ray_packages-feedstock` depends on **gymnasium ==0.26.3**