### PR TITLE
Rebuild for python 3.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/gymnasium-notices-feedstock/pr2/e805ee6
-
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/gymnasium-notices-feedstock/pr2/e805ee6
+
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bdb641c4cde0916aca339f736764b89077cdc147ed274a2ea6023c043c8d48e7
 
 build:
-  number: 0
+  number: 1
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:


### PR DESCRIPTION
Rebuild for python 3.11. ray 2.6.3 has a hard dependency on gymnasium 0.26.3 and we need it for python 3.11.

Channel: Defaults

Depends on:
* https://github.com/AnacondaRecipes/gymnasium-notices-feedstock/pull/2